### PR TITLE
Run the linters on ruby-3.2 (and pass them)

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
 
       - name: Cache gems
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ require `rspec/cover_it`, and then invoke `RSpec::CoverIt.setup`, with the
 appropriate options to configure it (described further down). A reasonable
 initial setup might look like this:
 
-```
+```ruby
 require "rspec/cover_it"
 project_root = File.expand_path("../..", __FILE__)
 RSpec::CoverIt.setup(filter: project_root, autoenforce: true)

--- a/lib/rspec/cover_it.rb
+++ b/lib/rspec/cover_it.rb
@@ -1,5 +1,8 @@
 require "coverage"
 
+# standardrb disallows this require _in ruby 3.2_, but we're back-compatible.
+require "set" # rubocop:disable Lint/RedundantRequireStatement
+
 module RSpec
   module CoverIt
     Error = Class.new(StandardError)

--- a/lib/rspec/cover_it/example_group_completeness_checker.rb
+++ b/lib/rspec/cover_it/example_group_completeness_checker.rb
@@ -1,5 +1,3 @@
-require "set"
-
 module RSpec
   module CoverIt
     class ExampleGroupCompletenessChecker


### PR DESCRIPTION
Started working on the new laptop and when I ran the suite on ruby-3.2, it failed. The linters are running in the GHA on ruby-3.1, and we should stay up to date.

* Run the linters github action on ruby-3.2 instead of 3.1
* Update the readme to comply with markdownlint (the fenced code-block needs a language specified)
* move the set-require up to the namespace definition, and give it a rubocop-ignore (in ruby 3.2, it's not required, and standardrb flags it as such. But we're compatible back to 2.7, and it should be present through ruby-3.1)